### PR TITLE
Fix the Clojure example

### DIFF
--- a/uapycon2012/index.html
+++ b/uapycon2012/index.html
@@ -765,7 +765,7 @@ Alexey, WTF?
 </code></pre>		
 
 <h3>Clojure</h3>
-<pre><code contenteditable class="clojure">(map #(%*2) '(1 2 3))
+<pre><code contenteditable class="clojure">(map #(* 2 %) [1 2 3])
 </code></pre>				
 
 <h3>Haskell</h3>


### PR DESCRIPTION
Could have used (partial \* 2), but I think the point was brevity
